### PR TITLE
Make errors adhere to spec

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,9 @@ type AbiHandler<abiFunc extends AbiFunction> = {
   handle: AbiFunctionHandler<abiFunc>;
 };
 
+const error = ({ status, message }: { status: number; message: string }) =>
+  json({ message }, { status });
+
 export const CcipReadRouter = <const options extends CcipReadRouterOptions>(
   {
     base,
@@ -121,16 +124,16 @@ export const CcipReadRouter = <const options extends CcipReadRouterOptions>(
             .then(({ sender, data }) => [sender, data]);
 
     if (!sender || !callData || !isAddress(sender) || !isHex(callData))
-      return json({ message: "Invalid request format" }, { status: 400 });
+      return error({ status: 400, message: "Invalid request format" });
 
     try {
       const response = await call({ to: sender, data: callData });
       return json(response.body, { status: response.status });
     } catch (e) {
-      return json(
-        { message: `Internal server error: ${(e as any).toString()}` },
-        { status: 500 }
-      );
+      return error({
+        status: 500,
+        message: `Internal server error: ${(e as any).toString()}`,
+      });
     }
   };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,5 @@
 import type { AbiParametersToPrimitiveTypes } from "abitype";
-import {
-  error,
-  json,
-  Router,
-  type IRequest,
-  type RouterOptions,
-} from "itty-router";
+import { json, Router, type IRequest, type RouterOptions } from "itty-router";
 import {
   decodeFunctionData,
   encodeFunctionResult,
@@ -80,9 +74,7 @@ export const CcipReadRouter = <const options extends CcipReadRouterOptions>(
       return {
         status: 404,
         body: {
-          data: {
-            error: `No implementation for function with selector ${selector}`,
-          },
+          message: `No implementation for function with selector ${selector}`,
         },
       };
 
@@ -129,14 +121,14 @@ export const CcipReadRouter = <const options extends CcipReadRouterOptions>(
             .then(({ sender, data }) => [sender, data]);
 
     if (!sender || !callData || !isAddress(sender) || !isHex(callData))
-      return error(400, "Invalid request format");
+      return json({ message: "Invalid request format" }, { status: 400 });
 
     try {
       const response = await call({ to: sender, data: callData });
       return json(response.body, { status: response.status });
     } catch (e) {
       return json(
-        { data: { error: `Internal server error: ${(e as any).toString()}` } },
+        { message: `Internal server error: ${(e as any).toString()}` },
         { status: 500 }
       );
     }

--- a/test/node/node.test.ts
+++ b/test/node/node.test.ts
@@ -254,9 +254,7 @@ test("returns an error when the function does not exist", async () => {
   expect(response.status).toBe(404);
   expect(result).toMatchInlineSnapshot(`
     {
-      "data": {
-        "error": "No implementation for function with selector 0xc2985578",
-      },
+      "message": "No implementation for function with selector 0xc2985578",
     }
   `);
 });
@@ -280,9 +278,7 @@ test("returns an error when the request throws an exception", async () => {
   expect(response.status).toBe(500);
   expect(result).toMatchInlineSnapshot(`
     {
-      "data": {
-        "error": "Internal server error: Error: Test error",
-      },
+      "message": "Internal server error: Error: Test error",
     }
   `);
 });
@@ -300,8 +296,7 @@ test("returns an error when invalid request format", async () => {
   expect(response.status).toBe(400);
   expect(result).toMatchInlineSnapshot(`
     {
-      "error": "Invalid request format",
-      "status": 400,
+      "message": "Invalid request format",
     }
   `);
 });

--- a/test/worker/worker.test.ts
+++ b/test/worker/worker.test.ts
@@ -67,9 +67,7 @@ it("returns an error when the function does not exist", async () => {
   );
   expect(await response.json()).toMatchInlineSnapshot(`
     {
-      "data": {
-        "error": "No implementation for function with selector 0xfa2cc503",
-      },
+      "message": "No implementation for function with selector 0xfa2cc503",
     }
   `);
 });


### PR DESCRIPTION
From [ERC-3668](https://eips.ethereum.org/EIPS/eip-3668)

---

Unsuccessful requests MUST return the appropriate HTTP status code - for example, 404 if the sender address is not supported by this gateway, 400 if the callData is in an invalid format, 500 if the server encountered an internal error, and so forth. If the Content-Type of a 4xx or 5xx response is application/json, it MUST adhere to the following JSON schema:

```
{
    "type": "object",
    "properties": {
        "message": {
            "type": "string",
            "description: "A human-readable error message."
        }
    }
}
```